### PR TITLE
Merge updated AppVeyor configuration for new bugs and updated packages

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,17 +26,17 @@ install:
   # Kill gpg-agent due to bug in MSYS
   - START /wait taskkill /f /im gpg-agent.exe
   # Download and install zstd for MSYS due to bug in MSYS
-  - appveyor DownloadFile http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-zstd-1.4.8-2-any.pkg.tar.zst
-  - zstd\zstd.exe -d mingw-w64-x86_64-zstd-1.4.8-2-any.pkg.tar.zst
+  - appveyor DownloadFile https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-zstd-1.5.5-1-any.pkg.tar.zst
+  - zstd\zstd.exe -d mingw-w64-x86_64-zstd-1.5.5-1-any.pkg.tar.zst
   - dir
-  - 7z a -tgzip mingw-w64-x86_64-zstd-1.4.8-2-any.pkg.tar.gz mingw-w64-x86_64-zstd-1.4.8-2-any.pkg.tar
-  - bash -lc "cd /c/projects/python-tksvg; ls -l; pacman --noconfirm -U mingw-w64-x86_64-zstd-1.4.8-2-any.pkg.tar.gz"
+  - 7z a -tgzip mingw-w64-x86_64-zstd-1.5.5-1-any.pkg.tar.gz mingw-w64-x86_64-zstd-1.5.5-1-any.pkg.tar
+  - bash -lc "cd /c/projects/python-tksvg; ls -l; pacman --noconfirm -U mingw-w64-x86_64-zstd-1.5.5-1-any.pkg.tar.gz"
   # Download and install pacman for MSYS due to bug in MSYS
-  - appveyor DownloadFile http://repo.msys2.org/msys/x86_64/pacman-5.2.2-9-x86_64.pkg.tar.zst
-  - zstd\zstd.exe -d pacman-5.2.2-9-x86_64.pkg.tar.zst
-  - dir
-  - 7z a -tgzip pacman-5.2.2-9-x86_64.pkg.tar.gz pacman-5.2.2-9-x86_64.pkg.tar
-  - bash -lc "cd /c/projects/python-tksvg; ls -l; pacman --noconfirm --nodeps --nodeps -U pacman-5.2.2-9-x86_64.pkg.tar.gz"
+  # - appveyor DownloadFile http://repo.msys2.org/msys/x86_64/pacman-5.2.2-9-x86_64.pkg.tar.zst
+  # - zstd\zstd.exe -d pacman-5.2.2-9-x86_64.pkg.tar.zst
+  # - dir
+  # - 7z a -tgzip pacman-5.2.2-9-x86_64.pkg.tar.gz pacman-5.2.2-9-x86_64.pkg.tar
+  # - bash -lc "cd /c/projects/python-tksvg; ls -l; pacman --noconfirm --nodeps --nodeps -U pacman-5.2.2-9-x86_64.pkg.tar.gz"
   # Cleanup after bug workarounds
   - bash -lc "rm -rf zstd"
   - bash -lc "rm -rf *.tar *.zst"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,13 +16,13 @@ install:
   - bash -lc "mv /etc/pacman.d/mirrorlist.mingw64.pacnew /etc/pacman.d/mirrorlist.mingw64"
   - bash -lc "mv /etc/pacman.d/mirrorlist.msys.pacnew /etc/pacman.d/mirrorlist.msys"
   # Load PGP Keys for Msys64
-  - appveyor DownloadFile https://repo.msys2.org/msys/x86_64/msys2-keyring-1~20210213-2-any.pkg.tar.zst
-  - appveyor DownloadFile https://repo.msys2.org/msys/x86_64/msys2-keyring-1~20210213-2-any.pkg.tar.zst.sig
+  - appveyor DownloadFile https://repo.msys2.org/msys/x86_64/msys2-keyring-1~20230703-1-any.pkg.tar.zst
+  - appveyor DownloadFile https://repo.msys2.org/msys/x86_64/msys2-keyring-1~20230703-1-any.pkg.tar.zst.sig
   - dir
-  - zstd\zstd.exe -d msys2-keyring-1~20210213-2-any.pkg.tar.zst
-  - bash -lc "cd /c/projects/python-tksvg; ls -l; pacman -U --noconfirm --config <(echo) msys2-keyring-1~20210213-2-any.pkg.tar"
+  - zstd\zstd.exe -d msys2-keyring-1~20230703-1-any.pkg.tar.zst
+  - bash -lc "cd /c/projects/python-tksvg; ls -l; pacman -U --noconfirm --config <(echo) msys2-keyring-1~20230703-1-any.pkg.tar"
   # Verify signature AFTER updating the keyring because MSYS messes with keys too much
-  - bash -lc "cd /c/projects/python-tksvg; ls -l; pacman-key --verify msys2-keyring-1~20210213-2-any.pkg.tar.zst.sig"
+  - bash -lc "cd /c/projects/python-tksvg; ls -l; pacman-key --verify msys2-keyring-1~20230703-1-any.pkg.tar.zst.sig"
   # Kill gpg-agent due to bug in MSYS
   - START /wait taskkill /f /im gpg-agent.exe
   # Download and install zstd for MSYS due to bug in MSYS

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,7 +12,9 @@ install:
   - zstd\zstd.exe -d pacman-mirrors-20221016-1-any.pkg.tar.zst
   - 7z a -tgzip pacman-mirrors-20221016-1-any.pkg.tar.gz pacman-mirrors-20221016-1-any.pkg.tar
   - bash -lc "cd /c/projects/python-tksvg; ls -l; pacman -U --overwrite=* --noconfirm --config <(echo) pacman-mirrors-20221016-1-any.pkg.tar.gz"
-  - bash -lc "mv /etc/pacman.d/mirrorlist.mingw.pacnew /etc/pacman.d/mirrorlist.mingw"
+  - bash -lc "mv /etc/pacman.d/mirrorlist.mingw32.pacnew /etc/pacman.d/mirrorlist.mingw32"
+  - bash -lc "mv /etc/pacman.d/mirrorlist.mingw64.pacnew /etc/pacman.d/mirrorlist.mingw64"
+  - bash -lc "mv /etc/pacman.d/mirrorlist.msys.pacnew /etc/pacman.d/mirrorlist.msys"
   # Load PGP Keys for Msys64
   - appveyor DownloadFile https://repo.msys2.org/msys/x86_64/msys2-keyring-1~20210213-2-any.pkg.tar.zst
   - appveyor DownloadFile https://repo.msys2.org/msys/x86_64/msys2-keyring-1~20210213-2-any.pkg.tar.zst.sig

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,6 +7,12 @@ install:
   # Download and unpack zstd for win64 to unpack MSYS packages
   - appveyor DownloadFile https://github.com/facebook/zstd/releases/download/v1.4.8/zstd-v1.4.8-win64.zip
   - 7z e zstd-v1.4.8-win64.zip -ozstd -y
+  # Download the MSYS2 mirror list (https://github.com/msys2/MSYS2-packages/issues/2589)
+  - appveyor DownloadFile https://mirror.msys2.org/msys/x86_64/pacman-mirrors-20221016-1-any.pkg.tar.zst
+  - zstd\zstd.exe -d pacman-mirrors-20221016-1-any.pkg.tar.zst
+  - 7z a -tgzip pacman-mirrors-20221016-1-any.pkg.tar.gz pacman-mirrors-20221016-1-any.pkg.tar
+  - bash -lc "cd /c/projects/python-tksvg; ls -l; pacman -U --overwrite=* --noconfirm --config <(echo) pacman-mirrors-20221016-1-any.pkg.tar.gz"
+  - bash -lc "mv /etc/pacman.d/mirrorlist.mingw.pacnew /etc/pacman.d/mirrorlist.mingw"
   # Load PGP Keys for Msys64
   - appveyor DownloadFile https://repo.msys2.org/msys/x86_64/msys2-keyring-1~20210213-2-any.pkg.tar.zst
   - appveyor DownloadFile https://repo.msys2.org/msys/x86_64/msys2-keyring-1~20210213-2-any.pkg.tar.zst.sig


### PR DESCRIPTION
This PR includes the following AppVeyor fixes:
- A work-around for https://github.com/msys2/MSYS2-packages/issues/2589
- Updated package versions
  The MSYS2 repositories keep only few old versions of packages, so the ones previously used are no longer available.
- The `pacman` package work-around is disabled (no longer needed)

TODO:
- [ ] Investigate and fix the execution of `cmake` (https://github.com/TkinterEP/python-tksvg/blob/master/setup.py#L64)

As requested in PR #1 .