### PR TITLE
Change to allow accepting svg content directly

### DIFF
--- a/tksvg/__init__.py
+++ b/tksvg/__init__.py
@@ -40,7 +40,7 @@ class SvgImage(tk.PhotoImage):
     """
     _svg_options = [("scale", float), ("scaletowidth", int), ("scaletoheight", int)]
 
-    def __init__(self, name=None, cnf={}, master=None, **kwargs):
+    def __init__(self, name=None, cnf={}, master=None, svg_content=None, **kwargs):
         self._svg_options_current = dict()
         # Load TkSVG package if not yet loaded
         master = master or tk._default_root
@@ -53,6 +53,10 @@ class SvgImage(tk.PhotoImage):
         # Initialize as a PhotoImage
         tk.PhotoImage.__init__(self, name, cnf, master, **kwargs)
         self.configure(**svg_options)
+
+        # Set the SVG content if provided
+        if svg_content is not None:
+            self.tk.call(self.name, 'configure', '-data', svg_content)
 
     def configure(self, **kwargs):
         """Configure the image with SVG options and pass to PhotoImage.configure"""


### PR DESCRIPTION
With this change the svg content does not necessarily have to be provided with a .svg file and can rather be provided in a variable which then may be passed to tksvg as function argument.

Merging and pushing this change to pypi, would be of big interest to me.

Thanks in advance